### PR TITLE
Modified identical answer finder

### DIFF
--- a/sentdex_lab/scoring.py
+++ b/sentdex_lab/scoring.py
@@ -51,19 +51,23 @@ def unk_checker(answer,score):
     
 
 def is_answer_identical(question, answer, score):
-    '''
-    if answer is the same, or very similar to the question, penalize.
-    '''
     try:
-        question = remove_punc(question)
-        answer = remove_punc(answer)
-            
-        if question == answer:
-            return score-4
-        if answer in question or question in answer:
-            return score-3
-        else:
-            return score
+        question = question.split(' ')
+        answer = answer.split(' ')
+        similarities = 0
+        for i in answer:
+            for j in question:
+                if i.lower() in j.lower() or j.lower() in i.lower():
+                    similarities += 1
+                    break
+        penalty = 0
+        if similarities > len(answer) / 1.8:
+            penalty = round((similarities / len(answer)) * 4, 1)
+        elif similarities > len(answer) / 2:
+            penalty = round((similarities / len(answer)) * 2.5, 1)
+        elif similarities > len(answer) / 4:
+            penalty = round((similarities / len(answer)) * 1.5, 1)
+        return score - penalty
     except Exception as e:
         print(str(e))
         return score

--- a/sentdex_lab/scoring.py
+++ b/sentdex_lab/scoring.py
@@ -160,7 +160,6 @@ def score_based_placement(idx, score):
 
 
 def do_scoring(question, answer, score):
-    score = is_answer_identical(question, answer, score)
     score = does_end_in_punctuation(answer,score)
     score = answer_echo(answer,score)
     score = answer_echo_question(question,answer,score)
@@ -168,6 +167,7 @@ def do_scoring(question, answer, score):
     score = unk_checker(answer,score)
     score = messedup_link(answer,score)
     score = bad_response(answer,score)
+    score = is_answer_identical(question, answer, score)
     return score
     
 


### PR DESCRIPTION
The old identical answer finder is not good enough because chatbot change some words slightly so the it not 100% identical strings but it's 100% identical answer to question.
Ex:-  Me: What is the speed of the light
        Bot: What's the speed of the light?
Those 2 are not identical strings but It says the same thing. So I changed is_answer_identical function to first separate words and then check how many similar words are in the 2 sentences and assign a weighted penalty by the number of similar words. I tested this function with my chat log with the Charles on Twitter. It work fine but I don't know how well this work on production server.
One more thing I think it's good if Charles stop giving any link. most of them are broken links and others are irrelevant.