### PR TITLE
Ignores decoding errors when reading files

### DIFF
--- a/setup/prepare_data.py
+++ b/setup/prepare_data.py
@@ -76,7 +76,7 @@ def prepare():
             with Pool(processes=preprocessing['cpu_count']) as pool:
 
                 # Count number of lines in file
-                number_of_records = min(amount, sum(1 for _ in open_function(source_file_name, 'rt', encoding='utf-8', **additioan_params)))
+                number_of_records = min(amount, sum(1 for _ in open_function(source_file_name, 'rt', encoding='utf-8', errors='ignore', **additioan_params)))
                 if file_name == '{}.{}'.format(hparams['train_prefix'].replace('.bpe', ''), hparams['src']).replace(preprocessing['train_folder'], '').lstrip('\\/'):
                     corpus_size = number_of_records
                     with open('{}/corpus_size'.format(preprocessing['train_folder']), 'w') as f:
@@ -86,7 +86,7 @@ def prepare():
                 progress = tqdm(ascii=True, unit=' lines', total=number_of_records)
 
                 # Open input file
-                with open_function(source_file_name, 'rt', encoding='utf-8', **additioan_params) as in_file:
+                with open_function(source_file_name, 'rt', encoding='utf-8', errors='ignore', **additioan_params) as in_file:
 
                     last_batch = False
 
@@ -423,18 +423,18 @@ def prepare():
                 # Progress bar
                 if file_name == '{}.{}'.format(hparams['train_prefix'], hparams['src']).replace(preprocessing['train_folder'], '').lstrip('\\/'):
                     if not corpus_size:
-                        with open('{}/corpus_size'.format(preprocessing['train_folder']), 'r') as f:
+                        with open('{}/corpus_size'.format(preprocessing['train_folder']), 'r', errors='ignore') as f:
                             number_of_records = corpus_size = int(f.read())
                     else:
                         number_of_records = corpus_size
                 elif file_name == '{}.{}'.format(hparams['train_prefix'], hparams['tgt']).replace(preprocessing['train_folder'], '').lstrip('\\/'):
                     number_of_records = corpus_size
                 else:
-                    number_of_records = sum(1 for _ in open('{}{}'.format(preprocessing['train_folder'], file_name.replace('.bpe.', '.')), 'r', encoding='utf-8', buffering=131072))
+                    number_of_records = sum(1 for _ in open('{}{}'.format(preprocessing['train_folder'], file_name.replace('.bpe.', '.')), 'r', encoding='utf-8', buffering=131072, errors='ignore'))
                 progress = tqdm(ascii=True, unit=' lines', total=number_of_records)
 
                 # Open input file
-                with open('{}{}'.format(preprocessing['train_folder'], file_name.replace('.bpe.', '.')), 'r', encoding='utf-8', buffering=131072) as in_file:
+                with open('{}{}'.format(preprocessing['train_folder'], file_name.replace('.bpe.', '.')), 'r', encoding='utf-8', buffering=131072, errors='ignore') as in_file:
 
                     # Iterate every 10k lines
                     for rows in read_lines(in_file, 10000, ''):


### PR DESCRIPTION
When I tried to use my own dataset (from the Cornell movies dialogues), it would throw
```
Traceback (most recent call last):
  File "prepare_data.py", line 563, in <module>
    prepare()
  File "prepare_data.py", line 79, in prepare
    number_of_records = min(amount, sum(1 for _ in open_function(source_file_name, 'rt', encoding='utf-8', **additioan_params)))
  File "prepare_data.py", line 79, in <genexpr>
    number_of_records = min(amount, sum(1 for _ in open_function(source_file_name, 'rt', encoding='utf-8', **additioan_params)))
  File "/usr/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xad in position 6816: invalid start byte
```
So I told it to ignore any decoding error like that. 
This just adds ease of use to the program.